### PR TITLE
fix namespaces error for conda installation as develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   - conda create -q -n test-environment python=$PYTHON_VERSION
   - source activate test-environment
   # Install dependencies
-  - conda install -c conda-forge numpy matplotlib opencv scikit-image
+  - conda install numpy matplotlib opencv scikit-image
   - conda install -c openalea openalea.deploy openalea.core
   # Install current package (no need --prefix=$CONDA_PREFIX with openalea.deploy)
   - python setup.py install

--- a/metainfo.ini
+++ b/metainfo.ini
@@ -5,7 +5,7 @@ release = 1.0.0
 ; must be in [openalea, vplants, alinea]
 project = openalea
 ; the filename of the egg
-name = OpenAlea.EarTrack
+name = openalea.eartrack
 ; default namespace
 namespace = openalea
 ; package is going to be used by Sphinx to create the title

--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,6 @@ setup(
     package_dir= package_dir,
 
     # Namespace packages creation by deploy
-    namespace_packages = [namespace],
-    create_namespaces = False,
     zip_safe= False,
 
     # Dependencies


### PR DESCRIPTION
Eartrack installation (at least as develop with conda)  breaks namespace of previous openalea installation.
This commit is just a modification of setup.py to not include namespace_packages.